### PR TITLE
0.1.21 - fixed bug in logic for explicitly specifying first ranks

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ ThisBuild / name := "cards"
 ThisBuild / organization := "io.github.jmisabella"
 ThisBuild / organizationName := "jmisabella"
 ThisBuild / organizationHomepage := Some(url("https://github.com/jmisabella"))
-ThisBuild / version := "0.1.20"
+ThisBuild / version := "0.1.21"
 ThisBuild / scalaVersion := "2.13.10"
 
 ThisBuild / scmInfo := Some(


### PR DESCRIPTION
0.1.21 - fixed bug in logic for explicitly specifying first ranks